### PR TITLE
Update postinstall definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "grunt test",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installing this as `npm` package it throws an error on bower. Changing the `postinstall` declaration to `bower install` fixes that issue. 